### PR TITLE
Update Solaris installation to support newer Facter

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,7 @@ class diamond::install {
         ensure_resource('package', ['python-pip','python-configobj','gcc','python-dev'], {'ensure' => 'present', 'before' => Package['diamond']})
       }
       'Solaris': {
-        case $::operatingsystemrelease {
+        case $::kernelrelease {
           '5.11': {
             ensure_resource('package', ['pip','solarisstudio-122'], {'ensure' => 'present', 'before' => Package['diamond']})
             file { ['/ws', '/ws/on11update-tools', '/ws/on11update-tools/SUNWspro']: ensure => directory, }

--- a/spec/classes/diamond/diamond_spec.rb
+++ b/spec/classes/diamond/diamond_spec.rb
@@ -191,7 +191,7 @@ describe 'diamond', :type => :class do
 
   context 'with enabling pip installation on Solaris' do
     let (:params) { {'install_from_pip' => true} }
-    let (:facts) { {:osfamily => 'Solaris', :operatingsystemrelease => '5.11'} }
+    let (:facts) { {:osfamily => 'Solaris', :kernelrelease => '5.11'} }
     it { should contain_package('solarisstudio-122').that_comes_before('Package[diamond]')}
     it { should contain_package('pip').that_comes_before('Package[diamond]')}
     it { should contain_package('diamond').with(


### PR DESCRIPTION
There has been a change in behavior around the $operatingsystemrelease
fact on Solaris between 1.x and 2.x.  This work updates the fact used
testing support on Solaris to use kernelrelease instead, as
kernelrelease behavior remains the same between versions, and is likely
more accurate for the usecase here.
